### PR TITLE
testing

### DIFF
--- a/criu/Makefile
+++ b/criu/Makefile
@@ -67,6 +67,7 @@ criu/pie/%: pie ;
 # CRIU executable
 PROGRAM-BUILTINS	+= criu/pie/pie.lib.a
 PROGRAM-BUILTINS	+= images/built-in.o
+PROGRAM-BUILTINS	+= flog/src/built-in.o
 PROGRAM-BUILTINS	+= $(obj)/built-in.o
 PROGRAM-BUILTINS	+= $(ARCH-LIB)
 PROGRAM-BUILTINS	+= soccr/libsoccr.a

--- a/criu/config.c
+++ b/criu/config.c
@@ -444,7 +444,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 		{OPT_NAME, no_argument, SAVE_TO, true},\
 		{"no-" OPT_NAME, no_argument, SAVE_TO, false}
 
-	static const char short_opts[] = "dSsRt:hD:o:v::x::Vr:jJ:lW:L:M:";
+	static const char short_opts[] = "dSsRt:hD:o:v:b::x::Vr:jJ:lW:L:M:";
 	static struct option long_opts[] = {
 		{ "tree",			required_argument,	0, 't'	},
 		{ "leave-stopped",		no_argument,		0, 's'	},
@@ -511,6 +511,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 		{ "status-fd",			required_argument,	0, 1088 },
 		BOOL_OPT(SK_CLOSE_PARAM, &opts.tcp_close),
 		{ "verbosity",			optional_argument,	0, 'v'	},
+		{ "binary-file",		optional_argument,	0, 'b' },
 		{ "ps-socket",			required_argument,	0, 1091},
 		BOOL_OPT("remote", &opts.remote),
 		{ "config",			required_argument,	0, 1089},
@@ -627,6 +628,9 @@ int parse_options(int argc, char **argv, bool *usage_error,
 					opts.log_level = atoi(optarg);
 			} else
 				opts.log_level++;
+			break;
+		case 'b':
+			opts.log_in_binary = true;
 			break;
 		case 1043: {
 			int fd;

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -153,6 +153,7 @@ struct cr_options {
 	char			*tls_key;
 	int			tls;
 	int			tls_no_cn_verify;
+	bool 		log_in_binary;
 };
 
 extern struct cr_options opts;

--- a/criu/log.c
+++ b/criu/log.c
@@ -225,7 +225,8 @@ int log_init(const char *output)
 	} else if (output) {
 		/*Changed the value here as the output is going to be
 		stored in a log file.*/
-		log_in_file = 1;
+		if(opts.log_in_binary)
+			log_in_file = 1;
 
 		new_logfd = open(output, O_CREAT|O_TRUNC|O_WRONLY|O_APPEND, 0600);
 		if (new_logfd < 0) {

--- a/flog/src/flog.c
+++ b/flog/src/flog.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <unistd.h>
+#include <string.h>
 #include <stdint.h>
 #include <sys/param.h>
 #include <sys/mman.h>
@@ -19,6 +20,7 @@ static char *mbuf = _mbuf;
 static char *fbuf;
 static uint64_t fsize;
 static uint64_t mbuf_size = sizeof(_mbuf);
+static int flog_enqueue(int fdout, flog_msg_t *m, const char *format);
 
 /*int flog_decode_all(int fdin, int fdout)
 {
@@ -75,9 +77,9 @@ static uint64_t mbuf_size = sizeof(_mbuf);
 	return 0;
 }*/
 
-static int flog_enqueue(flog_msg_t *m)
+static int flog_enqueue(int fdout, flog_msg_t *m, const char *format)
 {
-	if (write(1, m, m->size) != m->size) {
+	if (write(fdout, m, m->size) != m->size) {
 		fprintf(stderr, "Unable to write a message\n");
 		return -1;
 	}
@@ -87,6 +89,7 @@ static int flog_enqueue(flog_msg_t *m)
 /*extern char *rodata_start;
 extern char *rodata_end;
 */
+
 /* Pre-allocate a buffer in a file and map it into memory. */
 int flog_map_buf(int fdout)
 {
@@ -205,7 +208,7 @@ int flog_encode_msg(int fdout, unsigned int nargs, unsigned int mask, const char
 
 	m->size = roundup(m->size, 8);
 	if (mbuf == _mbuf) {
-		if (flog_enqueue(m))
+		if (flog_enqueue(fdout, m, format))
 			return -1;
 	} else {
 		mbuf += m->size;


### PR DESCRIPTION
Make changes to criu/log.c to enable binary logging

Change made through this commit are:
- When run with -o option, binary logs are generated into the specified file.
- When no file is specified the logs are printed normally in the terminal.